### PR TITLE
remove section about user defaults

### DIFF
--- a/iOS.md
+++ b/iOS.md
@@ -97,7 +97,6 @@ Use named constats, enums and structs. Don't use "magical" numbers or strings
 
 Put constants in its rightful place; in the class if only used in one class or in a shared class if used multiple places  
 Be conscious of access control, restrict access to parts of your code that's private. Also for UI elements (IBOutlets).  
-UserDefaults.synchronize blocks the UI thread, generally never use this method  
 Never block the UI thread. IO, calculation, etc, should be done in background threads  
 
 


### PR DESCRIPTION
I can only imagine this being a problem if the root problem is something else. You are doing / using UserDefaults for something it is not meant to be used for. If you are using UserDefaults even to the point that you would consider calling `synchronize` you should probably take a step back and reconsider what you are doing.

Side note: this would only block the main thread if called extensively and or is bloated. See original point.