### PR TITLE
remove obvious because obvious

### DIFF
--- a/iOS.md
+++ b/iOS.md
@@ -100,7 +100,6 @@ Be conscious of access control, restrict access to parts of your code that's pri
 
 ## Building User Interface
 
-Use Storyboards, Xibs and code according to need.  
 Use Storyboards for navigation and relationship between views  
 Keep Storyboards maintainable sizewise - use multiple smaller ones instead of one large  
 Use auto layout, contraints, size classes and stackviews to reuse interfaces between multiple screensizes  


### PR DESCRIPTION
The intentions behind this is good but it seems to be too broad to mean anything meaningful or tell outsiders how we do xib / storboards here at NRK. Some use them some do not. I guess "to need" can mean anything here.

TODO should be to explain what we do NOT want when dealing with xib and storboards. There are lot of things we _can_ be specific about. 

Opened an issue about this here
https://github.com/nrkno/best-practice/issues/12